### PR TITLE
fix(blog): restore erc-4337-vs-eoa markdown structure

### DIFF
--- a/content/blog/erc-4337-vs-eoa.md
+++ b/content/blog/erc-4337-vs-eoa.md
@@ -10,47 +10,176 @@ author: DexKit Team
 editorialType: comparison
 ---
 
-**Quick answer:** When comparing ERC-4337 and EOA wallets, you’re looking at two fundamentally different approaches to Ethereum account management. EOAs (Externally Owned Accounts) are simple, private key-controlled wallets—best for direct control and straightforward integrations. ERC-4337 introduces “account abstraction,” enabling smart contract wallets with programmable logic, flexible recovery, and advanced onboarding. EOAs suit experienced users and devs who want simplicity; ERC-4337 wallets are better for projects aiming to onboard mainstream users without complex key management. If you need a no-code way to build DApps with modern wallet support, DexAppBuilder is one visual option among several. ## Introduction to ERC-4337 and EOAs Ethereum wallets are a user’s gateway to Web3. For years, the default was the Externally Owned Account (EOA)—the kind you get with MetaMask or Ledger. But as user expectations grow, so does the need for better onboarding, security, and flexibility. That’s where ERC-4337 comes in, offering “account abstraction” and smart contract wallets that can do much more than a standard EOA. Before you decide which approach fits your project, it’s worth understanding what EOAs and ERC-4337 accounts are, and how they differ. ### What is an Externally Owned Account (EOA)? An Externally Owned Account is the original Ethereum wallet type. Every EOA is controlled by a single private key. If you’ve ever used MetaMask, Coinbase Wallet, or a hardware wallet, you’ve interacted with an EOA. **Key attributes of EOAs:**
+**Quick answer:** When comparing ERC-4337 and EOA wallets, you’re looking at two fundamentally different approaches to Ethereum account management. EOAs (Externally Owned Accounts) are simple, private key-controlled wallets—best for direct control and straightforward integrations. ERC-4337 introduces “account abstraction,” enabling smart contract wallets with programmable logic, flexible recovery, and advanced onboarding. EOAs suit experienced users and devs who want simplicity; ERC-4337 wallets are better for projects aiming to onboard mainstream users without complex key management. If you need a no-code way to build DApps with modern wallet support, DexAppBuilder is one visual option among several. 
+
+## Introduction to ERC-4337 and EOAs
+
+Ethereum wallets are a user’s gateway to Web3. For years, the default was the Externally Owned Account (EOA)—the kind you get with MetaMask or Ledger. But as user expectations grow, so does the need for better onboarding, security, and flexibility. That’s where ERC-4337 comes in, offering “account abstraction” and smart contract wallets that can do much more than a standard EOA. Before you decide which approach fits your project, it’s worth understanding what EOAs and ERC-4337 accounts are, and how they differ.
+
+### What is an Externally Owned Account (EOA)?
+
+An Externally Owned Account is the original Ethereum wallet type. Every EOA is controlled by a single private key. If you’ve ever used MetaMask, Coinbase Wallet, or a hardware wallet, you’ve interacted with an EOA. **Key attributes of EOAs:**
 - **Control:** Only you (or whoever holds the private key) can authorize transactions.
 - **Simplicity:** No smart contract code—just cryptographic signatures.
-- **Limitations:** No built-in social recovery, multi-signature, or custom rules. If you lose your key, you lose access. EOAs are the backbone of early Web3, but they put the burden of security and backup entirely on the user. ### What is ERC-4337 and Account Abstraction? ERC-4337 is an Ethereum standard that enables “account abstraction.” Instead of relying solely on private keys, ERC-4337 lets users control their wallets through smart contracts. These are often called “smart contract wallets” or “account abstraction wallets.” **What does account abstraction mean?** It separates the logic of account management from the base protocol, letting wallets define custom rules for authentication, recovery, transaction batching, and even who pays gas fees. **Key features enabled by ERC-4337:**
+- **Limitations:** No built-in social recovery, multi-signature, or custom rules. If you lose your key, you lose access.
+
+EOAs are the backbone of early Web3, but they put the burden of security and backup entirely on the user. 
+
+### What is ERC-4337 and Account Abstraction?
+
+ERC-4337 is an Ethereum standard that enables “account abstraction.” Instead of relying solely on private keys, ERC-4337 lets users control their wallets through smart contracts. These are often called “smart contract wallets” or “account abstraction wallets.” **What does account abstraction mean?** It separates the logic of account management from the base protocol, letting wallets define custom rules for authentication, recovery, transaction batching, and even who pays gas fees. **Key features enabled by ERC-4337:**
 - **Programmable security:** Social recovery, multi-signature, spending limits—baked into the wallet.
 - **Flexible onboarding:** Log in with email, phone, or social accounts.
 - **Gasless transactions:** Let apps or third parties pay gas fees for users.
-- **Upgradability:** Wallet logic can evolve over time. ERC-4337 works by introducing a new “UserOperation” flow, handled by decentralized “bundlers” and “paymasters,” instead of direct transactions from EOAs. ## Core Differences Between ERC-4337 and EOA Wallets The shift from EOAs to ERC-4337 smart contract wallets changes the user experience and technical capabilities in several ways. Let’s break down the main differences. ### Security and Key Management **EOA wallets:** - Security is binary: you either control the private key, or you don’t.
-- If you lose your key or seed phrase, there’s no recovery. - No support for multi-signature (without extra contracts), social recovery, or time-locked transactions. **ERC-4337 wallets:** - Key management can be flexible: allow social recovery, multi-signature, hardware keys, or even biometrics.
+- **Upgradability:** Wallet logic can evolve over time. 
+
+ERC-4337 works by introducing a new “UserOperation” flow, handled by decentralized “bundlers” and “paymasters,” instead of direct transactions from EOAs. 
+
+## Core Differences Between ERC-4337 and EOA Wallets
+
+The shift from EOAs to ERC-4337 smart contract wallets changes the user experience and technical capabilities in several ways. Let’s break down the main differences.
+
+### Security and Key Management
+
+**EOA wallets:**
+- Security is binary: you either control the private key, or you don’t.
+- If you lose your key or seed phrase, there’s no recovery.
+- No support for multi-signature (without extra contracts), social recovery, or time-locked transactions.
+
+**ERC-4337 wallets:**
+- Key management can be flexible: allow social recovery, multi-signature, hardware keys, or even biometrics.
 - Recovery mechanisms can be programmed directly into the wallet contract.
-- Security models can be tailored for individuals, organizations, or app-specific needs. **Trade-off:** EOAs are simple and familiar, but unforgiving if a key is lost. ERC-4337 wallets can be safer for mainstream users but add complexity and require more careful contract design. ### User Experience and Onboarding **EOA wallets:** - Users must generate and back up a seed phrase.
+- Security models can be tailored for individuals, organizations, or app-specific needs.
+
+**Trade-off:** EOAs are simple and familiar, but unforgiving if a key is lost. ERC-4337 wallets can be safer for mainstream users but add complexity and require more careful contract design. 
+
+### User Experience and Onboarding
+
+**EOA wallets:**
+- Users must generate and back up a seed phrase.
 - Onboarding is intimidating for non-technical users.
-- Every transaction requires manual signature and gas payment. **ERC-4337 wallets:** - Users can sign up with familiar methods (email, social login, phone) if the wallet supports it.
+- Every transaction requires manual signature and gas payment.
+
+**ERC-4337 wallets:**
+- Users can sign up with familiar methods (email, social login, phone) if the wallet supports it.
 - Apps can sponsor gas for new users, enabling “gasless” transactions.
-- Batch transactions and custom flows (like approve + swap in one step) are possible. **For example:** A DApp startup wants to onboard users who have never used crypto before. With ERC-4337 wallets, they can offer email sign-up and cover gas fees for the first few transactions, removing friction that would stop most users with an EOA. ### Gas Fees and Transaction Handling **EOA wallets:** - Every transaction must be signed and paid for by the user.
+- Batch transactions and custom flows (like approve + swap in one step) are possible.
+
+**For example:** A DApp startup wants to onboard users who have never used crypto before. With ERC-4337 wallets, they can offer email sign-up and cover gas fees for the first few transactions, removing friction that would stop most users with an EOA. 
+
+### Gas Fees and Transaction Handling
+
+**EOA wallets:**
+- Every transaction must be signed and paid for by the user.
 - No batching—each action is a separate transaction.
-- Users must hold ETH for gas, creating an onboarding hurdle. **ERC-4337 wallets:** - Apps or third parties (via “paymasters”) can pay gas fees, enabling gasless onboarding.
+- Users must hold ETH for gas, creating an onboarding hurdle.
+
+**ERC-4337 wallets:**
+- Apps or third parties (via “paymasters”) can pay gas fees, enabling gasless onboarding.
 - Transactions can be batched—multiple actions in one signature.
-- Users can interact with DApps before acquiring ETH. **Trade-off:** ERC-4337 reduces onboarding friction and supports more complex flows. However, it introduces extra infrastructure (bundlers, paymasters) and can add contract deployment costs. ## How the Options Compare With account abstraction gaining traction, more tools are emerging to help projects adopt ERC-4337 or stick with EOAs. Here’s a side-by-side look at leading wallet/auth solutions—each with different strengths, limitations, and fit for various project types. | Product | Best for | Honest limitations | Account type(s) supported | Visual DApp builder? |
+- Users can interact with DApps before acquiring ETH.
+
+**Trade-off:** ERC-4337 reduces onboarding friction and supports more complex flows. However, it introduces extra infrastructure (bundlers, paymasters) and can add contract deployment costs. 
+
+## How the Options Compare
+
+With account abstraction gaining traction, more tools are emerging to help projects adopt ERC-4337 or stick with EOAs. Here’s a side-by-side look at leading wallet/auth solutions—each with different strengths, limitations, and fit for various project types.
+
+| Product | Best for | Honest limitations | Account type(s) supported | Visual DApp builder? |
 |-----------------|-------------------------------------------|----------------------------------------------------------------|----------------------------------|---------------------------|
 | **Privy** | Embedded wallet and Web3 onboarding/auth | Auth layer only, not a full DApp builder | EOA, some smart wallets | No |
 | **Dynamic** | Multi-wallet auth and onboarding widgets | Onboarding-focused; no full DApp editor or NFT storefront | EOA, ERC-4337 | No |
 | **Thirdweb** | Dev-focused SDK and embeddable widgets | Dev-first; less visual full-DApp builder than DexAppBuilder | EOA, ERC-4337 | Limited (contract deploy) |
-| **DexAppBuilder** | No-code end-to-end DApp builder | Not ideal for pure auth or marketing-only sites | EOA, ERC-4337 (via Thirdweb) | Yes | ### Privy: Embedded Wallet and Auth Layer Privy focuses on simplifying Web3 onboarding by embedding wallets directly into your app and supporting familiar login methods (email, social, phone). It abstracts away the complexity of EOAs for end users, but under the hood, it typically creates an EOA or smart wallet for each user. **Pros:** - Fast onboarding with minimal user friction.
-- Good for consumer apps, NFT drops, and any project prioritizing mainstream accessibility. **Cons:** - Primarily an authentication layer; not a full DApp builder.
-- Less control if you want to customize wallet logic or DApp UI. **Best for:** Projects that need quick, user-friendly onboarding but don’t need a visual DApp builder or advanced wallet features. ### Dynamic: Multi-Wallet Auth and Onboarding Dynamic provides a suite of onboarding widgets and authentication options, supporting both EOAs and ERC-4337 wallets. It’s designed to make connecting multiple wallet types easy, handling session management and user identity. **Pros:** - Smooth integration of multiple wallet types in one UX.
-- Good for projects targeting a broad user base, from crypto-native to mainstream. **Cons:** - Focused on onboarding—does not offer a full DApp editor, NFT store, or visual builder.
-- For more complex DApp needs, you’ll need to build the rest yourself. **Best for:** Teams who want to offer the latest wallet standards (including ERC-4337) but don’t need a drag-and-drop DApp builder. ### Thirdweb: Dev-Focused SDK and Widgets Thirdweb is popular among developers for its SDKs, embeddable widgets, and contract templates. It supports both EOAs and ERC-4337 smart wallets, and offers tools for NFT drops, marketplaces, and in-app payments. **Pros:** - Powerful contract deployment and management tools.
-- Embeddable widgets for common Web3 flows (Connect, Mint, Pay). **Cons:** - Less visual than some no-code builders; requires some coding.
-- Full DApp creation and layout require developer effort. **Note:** the builder deploys Thirdweb contracts via DexContracts, combining no-code editing with Thirdweb’s robust contract library. **Best for:** Developers who want flexibility and control, and are comfortable working with SDKs. ### DexAppBuilder: No-Code End-to-End DApp Builder the builder is a visual, no-code DApp builder that lets you create full-featured Web3 apps—including wallet onboarding, NFT stores, and token swaps—without writing Solidity. It integrates with Thirdweb contracts via DexContracts, so you get the benefits of account abstraction and ERC-4337 wallets along with visual editing. **Pros:** - End-to-end DApp creation: wallet onboarding, NFT store, swaps, and more.
+| **DexAppBuilder** | No-code end-to-end DApp builder | Not ideal for pure auth or marketing-only sites | EOA, ERC-4337 (via Thirdweb) | Yes | 
+
+### Privy: Embedded Wallet and Auth Layer
+
+Privy focuses on simplifying Web3 onboarding by embedding wallets directly into your app and supporting familiar login methods (email, social, phone). It abstracts away the complexity of EOAs for end users, but under the hood, it typically creates an EOA or smart wallet for each user.
+
+**Pros:**
+- Fast onboarding with minimal user friction.
+- Good for consumer apps, NFT drops, and any project prioritizing mainstream accessibility.
+
+**Cons:**
+- Primarily an authentication layer; not a full DApp builder.
+- Less control if you want to customize wallet logic or DApp UI.
+
+**Best for:** Projects that need quick, user-friendly onboarding but don’t need a visual DApp builder or advanced wallet features. 
+
+### Dynamic: Multi-Wallet Auth and Onboarding
+
+Dynamic provides a suite of onboarding widgets and authentication options, supporting both EOAs and ERC-4337 wallets. It’s designed to make connecting multiple wallet types easy, handling session management and user identity.
+
+**Pros:**
+- Smooth integration of multiple wallet types in one UX.
+- Good for projects targeting a broad user base, from crypto-native to mainstream.
+
+**Cons:**
+- Focused on onboarding—does not offer a full DApp editor, NFT store, or visual builder.
+- For more complex DApp needs, you’ll need to build the rest yourself.
+
+**Best for:** Teams who want to offer the latest wallet standards (including ERC-4337) but don’t need a drag-and-drop DApp builder. 
+
+### Thirdweb: Dev-Focused SDK and Widgets
+
+Thirdweb is popular among developers for its SDKs, embeddable widgets, and contract templates. It supports both EOAs and ERC-4337 smart wallets, and offers tools for NFT drops, marketplaces, and in-app payments.
+
+**Pros:**
+- Powerful contract deployment and management tools.
+- Embeddable widgets for common Web3 flows (Connect, Mint, Pay).
+
+**Cons:**
+- Less visual than some no-code builders; requires some coding.
+- Full DApp creation and layout require developer effort.
+
+**Note:** the builder deploys Thirdweb contracts via DexContracts, combining no-code editing with Thirdweb’s robust contract library.
+
+**Best for:** Developers who want flexibility and control, and are comfortable working with SDKs. 
+
+### DexAppBuilder: No-Code End-to-End DApp Builder
+
+the builder is a visual, no-code DApp builder that lets you create full-featured Web3 apps—including wallet onboarding, NFT stores, and token swaps—without writing Solidity. It integrates with Thirdweb contracts via DexContracts, so you get the benefits of account abstraction and ERC-4337 wallets along with visual editing.
+
+**Pros:**
+- End-to-end DApp creation: wallet onboarding, NFT store, swaps, and more.
 - No coding required—add Wallet, Swap, NFT store, and other sections visually.
-- Multi-chain deploy with a unified workflow. **Cons:** - Not ideal for pure marketing websites or projects that only need an auth layer (Privy/Dynamic may be simpler).
-- Less suitable for enterprise protocols requiring full code control. **Best for:** Creators and startups who want to launch a branded, functional DApp quickly, with modern wallet support, and without hiring a Solidity dev. ## Choosing the Right Wallet Solution for Your Project There’s no universal answer. Your ideal wallet approach depends on your audience, technical resources, and product goals. ### When to Use EOAs EOAs are still a solid choice if:
+- Multi-chain deploy with a unified workflow.
+
+**Cons:**
+- Not ideal for pure marketing websites or projects that only need an auth layer (Privy/Dynamic may be simpler).
+- Less suitable for enterprise protocols requiring full code control.
+
+**Best for:** Creators and startups who want to launch a branded, functional DApp quickly, with modern wallet support, and without hiring a Solidity dev. 
+
+## Choosing the Right Wallet Solution for Your Project
+
+There’s no universal answer. Your ideal wallet approach depends on your audience, technical resources, and product goals.
+
+### When to Use EOAs
+
+EOAs are still a solid choice if:
 - You’re building for crypto-native users who expect MetaMask or Ledger integration.
 - You want maximum simplicity and direct control over wallet logic.
 - Your app doesn’t require advanced features like social recovery or gasless transactions.
-- You need to minimize contract deployment costs. **Recommendation:** If your users are comfortable with seed phrases and manual gas payments, EOAs remain the simplest and most battle-tested option. ### When ERC-4337 Wallets Make Sense ERC-4337 wallets are the better fit when:
+- You need to minimize contract deployment costs.
+
+**Recommendation:** If your users are comfortable with seed phrases and manual gas payments, EOAs remain the simplest and most battle-tested option. 
+
+### When ERC-4337 Wallets Make Sense
+
+ERC-4337 wallets are the better fit when:
 - You’re targeting mainstream users who don’t want to deal with seed phrases or private keys.
 - Your app benefits from social recovery, programmable spending limits, or multi-signature approvals.
 - You want to enable gasless transactions or batch complex flows into a single signature.
-- You’re building for mobile, social, or gaming audiences who expect modern onboarding. **For example:** A gaming DApp on Polygon wants to onboard users via email, let parents set spending limits for kids, and cover gas costs for early adopters. An ERC-4337 wallet architecture makes all of this possible—whereas EOAs would require third-party custodians or awkward workarounds. --- ## Feature Checklist | Feature | Why it matters | In DexAppBuilder? |
+- You’re building for mobile, social, or gaming audiences who expect modern onboarding.
+
+**For example:** A gaming DApp on Polygon wants to onboard users via email, let parents set spending limits for kids, and cover gas costs for early adopters. An ERC-4337 wallet architecture makes all of this possible—whereas EOAs would require third-party custodians or awkward workarounds.
+
+---
+
+## Feature Checklist
+
+| Feature | Why it matters | In DexAppBuilder? |
 |----------------------------|---------------------------------------------------------------------|----------------------------|
 | Smart contract wallet (ERC-4337) | Enables programmable security, recovery, and onboarding | Yes (via Thirdweb) |
 | Visual DApp builder | Non-devs can create full DApps with wallet, NFT store, swap, etc. | Yes |
@@ -58,4 +187,38 @@ editorialType: comparison
 | Auth-only onboarding | Simplifies login (email, social) for non-crypto users | Not a core focus |
 | NFT marketplace section | Launch NFT stores and collections visually | Yes (NFT store, Featured NFTs, Collection List) |
 | Advanced custom flows | Batch actions, custom rules in wallet logic | Yes (via contract templates) |
-| Pure marketing site | For non-Web3, informational landing pages | No | --- ## FAQ ### What is the main difference between ERC-4337 and an EOA? ERC-4337 introduces account abstraction, allowing wallets to be programmable smart contracts with custom logic for security, onboarding, and transaction handling. EOAs are traditional wallets controlled solely by a private key, with no built-in programmability or recovery options. ### Can ERC-4337 wallets reduce gas fees compared to EOAs? ERC-4337 wallets can enable flexible transaction fee payment methods. Through paymasters, apps or third parties can sponsor gas fees, allowing for “gasless” transactions that improve onboarding compared to traditional EOAs where users must always pay their own gas. ### Is DexAppBuilder compatible with ERC-4337 wallets? Yes, the builder supports deploying smart contract wallets leveraging ERC-4337 via DexContracts. This means you can build DApps with advanced wallet logic and onboarding features—without coding—using the visual builder. ### When should I choose a simple EOA over ERC-4337 wallets? Choose EOAs if you need a straightforward, developer-controlled wallet, value simplicity, and are building for users who are comfortable managing private keys and seed phrases. EOAs have fewer moving parts and lower deployment costs. ### Are there any limitations to ERC-4337 wallets? ERC-4337 wallets add extra complexity and require deploying a smart contract for each user wallet, which may not be ideal for projects needing the simplest possible onboarding or just an authentication layer. They also depend on new infrastructure (bundlers, paymasters) that’s still maturing. ### Can I migrate an existing EOA to an ERC-4337 smart contract wallet? You cannot convert an EOA directly to an ERC-4337 wallet, but you can build flows for users to “upgrade” to a smart wallet by deploying a new contract and transferring assets. This often involves user education and extra steps. ### Do ERC-4337 wallets work on all Ethereum-compatible chains? Most EVM-compatible chains (like Polygon, Arbitrum, Optimism) are adding support for ERC-4337, but infrastructure maturity and paymaster support can vary. Always check chain support before deploying at scale. ## Related reads - [ERC-4337 and Account Abstraction Guide](/blog/erc-4337-account-abstraction-guide)
+| Pure marketing site | For non-Web3, informational landing pages | No | --- 
+
+## FAQ
+
+### What is the main difference between ERC-4337 and an EOA?
+
+ERC-4337 introduces account abstraction, allowing wallets to be programmable smart contracts with custom logic for security, onboarding, and transaction handling. EOAs are traditional wallets controlled solely by a private key, with no built-in programmability or recovery options.
+
+### Can ERC-4337 wallets reduce gas fees compared to EOAs?
+
+ERC-4337 wallets can enable flexible transaction fee payment methods. Through paymasters, apps or third parties can sponsor gas fees, allowing for “gasless” transactions that improve onboarding compared to traditional EOAs where users must always pay their own gas.
+
+### Is DexAppBuilder compatible with ERC-4337 wallets?
+
+Yes, the builder supports deploying smart contract wallets leveraging ERC-4337 via DexContracts. This means you can build DApps with advanced wallet logic and onboarding features—without coding—using the visual builder.
+
+### When should I choose a simple EOA over ERC-4337 wallets?
+
+Choose EOAs if you need a straightforward, developer-controlled wallet, value simplicity, and are building for users who are comfortable managing private keys and seed phrases. EOAs have fewer moving parts and lower deployment costs.
+
+### Are there any limitations to ERC-4337 wallets?
+
+ERC-4337 wallets add extra complexity and require deploying a smart contract for each user wallet, which may not be ideal for projects needing the simplest possible onboarding or just an authentication layer. They also depend on new infrastructure (bundlers, paymasters) that’s still maturing.
+
+### Can I migrate an existing EOA to an ERC-4337 smart contract wallet?
+
+You cannot convert an EOA directly to an ERC-4337 wallet, but you can build flows for users to “upgrade” to a smart wallet by deploying a new contract and transferring assets. This often involves user education and extra steps.
+
+### Do ERC-4337 wallets work on all Ethereum-compatible chains?
+
+Most EVM-compatible chains (like Polygon, Arbitrum, Optimism) are adding support for ERC-4337, but infrastructure maturity and paymaster support can vary. Always check chain support before deploying at scale.
+
+## Related reads
+
+- [ERC-4337 and Account Abstraction Guide](/blog/erc-4337-account-abstraction-guide)


### PR DESCRIPTION
## Summary
- Restores paragraph/heading newlines in `content/blog/erc-4337-vs-eoa.md` so `##`/`###` and lists render instead of raw markdown in one blob.
- Root cause fixed in seo-content-engine (`injectLinks` used `\s{2,}`, which collapses `\n\n`).

## Test plan
- [ ] Preview https://dexkit.com/blog/erc-4337-vs-eoa after merge/deploy
- [ ] Confirm H2/H3 headings render as real headings
- [ ] Confirm comparison + feature tables render
- [ ] Spot-check list formatting under Security / Pros-Cons sections


Made with [Cursor](https://cursor.com)